### PR TITLE
Use development branches for modules in unstable bundle

### DIFF
--- a/.test/tests/valkey-integration-tests/run.sh
+++ b/.test/tests/valkey-integration-tests/run.sh
@@ -148,7 +148,8 @@ run_tests() {
 
             docker run -d -p $VALKEY_PORT:6379 --name "$CONTAINER_NAME" "$image" \
                 valkey-server \
-                --enable-debug-command yes >/dev/null 2>&1
+                --enable-debug-command yes \
+                --json.debug-mode yes >/dev/null 2>&1
             sleep 3
 
             export SOURCE_DIR="$(pwd)"

--- a/.test/tests/valkey-integration-tests/run.sh
+++ b/.test/tests/valkey-integration-tests/run.sh
@@ -70,19 +70,15 @@ repos=("valkey" "valkey-json" "valkey-bloom" "valkey-search" "valkey-ldap")
 
 for repo in "${repos[@]}"; do
     if [ ! -d "./$repo" ]; then
-        if [[ "$repo" == "valkey" ]]; then
-            echo "Cloning $repo from tag $VALKEY_TAG"
-            git clone -b "$VALKEY_TAG" --depth=1 "https://github.com/valkey-io/$repo.git" "./$repo"
-        elif [[ "$repo" == "valkey-json" ]]; then
-            echo "Cloning $repo from version tag $JSON_TAG"
-            git clone -b "$JSON_TAG" --depth=1 "https://github.com/valkey-io/$repo.git" "./$repo"
-        elif [[ "$repo" == "valkey-bloom" ]]; then
-            echo "Cloning $repo from version tag $BLOOM_TAG"
-            git clone -b "$BLOOM_TAG" --depth=1 "https://github.com/valkey-io/$repo.git" "./$repo"
-        else
-            echo "Cloning $repo from main branch"
-            git clone --depth=1 "https://github.com/valkey-io/$repo.git" "./$repo"
-        fi
+        case "$repo" in
+            valkey)       tag="$VALKEY_TAG" ;;
+            valkey-json)  tag="$JSON_TAG" ;;
+            valkey-bloom) tag="$BLOOM_TAG" ;;
+            valkey-search) tag="$SEARCH_TAG" ;;
+            valkey-ldap)  tag="$LDAP_TAG" ;;
+        esac
+        echo "Cloning $repo from branch/tag $tag"
+        git clone -b "$tag" --depth=1 "https://github.com/valkey-io/$repo.git" "./$repo"
     fi
 done
 

--- a/scripts/update-versions.py
+++ b/scripts/update-versions.py
@@ -90,13 +90,6 @@ def fetch_latest_module_versions(known_modules: Dict[str, str]) -> Dict[str, Dic
     """Fetch latest release for each module and return as {name: {"version": ...}} dict."""
     return {name: {"version": get_latest_module_release(repo)} for name, repo in known_modules.items()}
 
-def update_unstable(versions_data: Dict[str, Any]) -> Dict[str, Any]:
-    """Update the unstable block with latest stable module releases."""
-    known_modules = get_known_modules_from_versions(versions_data)
-    versions_data["unstable"]["modules"] = fetch_latest_module_versions(known_modules)
-    versions_data["unstable"]["debian"]["version"] = get_debian_version('unstable')
-    return versions_data
-
 def update_versions(versions_data: Dict[str, Any], component_name: str, new_version: str) -> Dict[str, Any]:
     """Update versions.json according to Valkey and module versioning strategy."""
     major, minor, patch, rc = parse_version(new_version)
@@ -158,6 +151,7 @@ def update_versions(versions_data: Dict[str, Any], component_name: str, new_vers
             
             versions_data[new_major_minor_release] = new_entry
 
+        versions_data["unstable"]["debian"]["version"] = get_debian_version('unstable')
         return versions_data
 
     else:
@@ -211,15 +205,23 @@ def update_versions(versions_data: Dict[str, Any], component_name: str, new_vers
         except subprocess.CalledProcessError:
             bump_bundle_if_needed(versions_data, latest)
         
+        versions_data["unstable"]["debian"]["version"] = get_debian_version('unstable')
         return versions_data
 
 if __name__ == "__main__":
-    if len(sys.argv) < 3 or (sys.argv[2] != 'unstable' and len(sys.argv) != 4):
-        logging.error("Incorrect parameters. Usage: update_versions.py <json_file> <component [valkey, json, bloom, etc | unstable]> [new_version]")
+    if len(sys.argv) != 4:
+        logging.error("Incorrect parameters. Usage: update_versions.py <json_file> <component [valkey, json, bloom, etc]> <new_version>")
         sys.exit(1)
 
     json_file = sys.argv[1]
     component_name = sys.argv[2]
+    new_version = sys.argv[3]
+
+    try:
+        parse_version(new_version)
+    except ValueError as version_error:
+        logging.error(version_error)
+        sys.exit(1)
 
     try:
         with open(json_file, 'r') as f:
@@ -229,18 +231,7 @@ if __name__ == "__main__":
         sys.exit(1)
 
     original_data = json.dumps(versions_data, indent=2)
-
-    if component_name == 'unstable':
-        updated_file = update_unstable(versions_data)
-    else:
-        new_version = sys.argv[3]
-        try:
-            parse_version(new_version)
-        except ValueError as version_error:
-            logging.error(version_error)
-            sys.exit(1)
-        updated_file = update_versions(versions_data, component_name, new_version)
-
+    updated_file = update_versions(versions_data, component_name, new_version)
     updated_data = json.dumps(updated_file, indent=2)
     changed = original_data != updated_data
 
@@ -248,9 +239,7 @@ if __name__ == "__main__":
         f.write(updated_data)
         f.write('\n')
 
-    if component_name == 'unstable':
-        label = "unstable block"
-    elif component_name == 'valkey':
+    if component_name == 'valkey':
         label = f"{component_name} to {new_version}"
     else:
         label = f"valkey-{component_name} to {new_version}"

--- a/tests/test_update_versions.py
+++ b/tests/test_update_versions.py
@@ -14,7 +14,6 @@ update_versions = importlib.import_module("update-versions")
 parse_version = update_versions.parse_version
 get_latest_major_minor = update_versions.get_latest_major_minor
 get_known_modules_from_versions = update_versions.get_known_modules_from_versions
-update_unstable = update_versions.update_unstable
 update_versions_fn = update_versions.update_versions
 
 
@@ -76,52 +75,6 @@ class TestGetKnownModules:
     def test_repo_names(self, versions_data):
         modules = get_known_modules_from_versions(versions_data)
         assert modules["valkey-json"] == "valkey-io/valkey-json"
-
-
-# ---------------------------------------------------------------------------
-# update_unstable
-# ---------------------------------------------------------------------------
-class TestUpdateUnstable:
-    def test_updates_module_versions(self, versions_data, mocker):
-        mocker.patch.object(
-            update_versions, "get_latest_module_release",
-            side_effect=lambda repo: {
-                "valkey-io/valkey-json": "1.1.0",
-                "valkey-io/valkey-bloom": "1.1.0",
-                "valkey-io/valkey-search": "1.1.0",
-                "valkey-io/valkey-ldap": "1.1.0",
-            }[repo],
-        )
-        mocker.patch.object(
-            update_versions, "get_debian_version", return_value="trixie"
-        )
-
-        result = update_unstable(versions_data)
-        for mod in ["valkey-json", "valkey-bloom", "valkey-search", "valkey-ldap"]:
-            assert result["unstable"]["modules"][mod]["version"] == "1.1.0"
-
-    def test_updates_debian_version(self, versions_data, mocker):
-        mocker.patch.object(
-            update_versions, "get_latest_module_release", return_value="1.0.0"
-        )
-        mocker.patch.object(
-            update_versions, "get_debian_version", return_value="trixie"
-        )
-
-        result = update_unstable(versions_data)
-        assert result["unstable"]["debian"]["version"] == "trixie"
-
-    def test_does_not_touch_other_blocks(self, versions_data, mocker):
-        original_81 = copy.deepcopy(versions_data["8.1"])
-        mocker.patch.object(
-            update_versions, "get_latest_module_release", return_value="1.0.0"
-        )
-        mocker.patch.object(
-            update_versions, "get_debian_version", return_value="bookworm"
-        )
-
-        result = update_unstable(versions_data)
-        assert result["8.1"] == original_81
 
 
 # ---------------------------------------------------------------------------
@@ -256,6 +209,13 @@ class TestUpdateVersionsValkey:
         # 8.1 is not latest, so GA downgrade should NOT run — RC module stays
         assert result["8.1"]["modules"]["valkey-search"]["version"] == "1.1.0-rc1"
 
+    def test_valkey_update_syncs_unstable_debian(self, versions_data, mocker):
+        mocker.patch.object(update_versions, "get_debian_version", return_value="trixie")
+        self._no_open_pr(mocker)
+
+        result = update_versions_fn(versions_data, "valkey", "9.0.5")
+        assert result["unstable"]["debian"]["version"] == "trixie"
+
 
 # ---------------------------------------------------------------------------
 # update_versions — module component
@@ -268,6 +228,7 @@ class TestUpdateVersionsModule:
         mocker.patch("subprocess.check_output", return_value=b"abc123\trefs/heads/valkey-bundle-update\n")
 
     def test_module_patch_updates_matching_blocks(self, versions_data, mocker):
+        mocker.patch.object(update_versions, "get_debian_version", return_value="bookworm")
         self._no_open_pr(mocker)
 
         # valkey-json 1.0.1 exists in 8.1 and 9.0 — patch 1.0.2 should update both
@@ -276,12 +237,14 @@ class TestUpdateVersionsModule:
         assert result["9.0"]["modules"]["valkey-json"]["version"] == "1.0.2"
 
     def test_module_patch_does_not_touch_unstable(self, versions_data, mocker):
+        mocker.patch.object(update_versions, "get_debian_version", return_value="bookworm")
         self._no_open_pr(mocker)
         original_unstable = copy.deepcopy(versions_data["unstable"])
         update_versions_fn(versions_data, "json", "1.0.2")
         assert versions_data["unstable"] == original_unstable
 
     def test_module_patch_updates_three_blocks(self, versions_data_three_blocks, mocker):
+        mocker.patch.object(update_versions, "get_debian_version", return_value="bookworm")
         self._no_open_pr(mocker)
         # json is 1.0.1 in 8.1, 9.0, and 9.1 — patch should update all three
         result = update_versions_fn(versions_data_three_blocks, "json", "1.0.2")
@@ -290,6 +253,7 @@ class TestUpdateVersionsModule:
         assert result["9.1"]["modules"]["valkey-json"]["version"] == "1.0.2"
 
     def test_module_patch_does_not_update_different_major_minor(self, versions_data, mocker):
+        mocker.patch.object(update_versions, "get_debian_version", return_value="bookworm")
         self._no_open_pr(mocker)
 
         # valkey-search is 1.0.1 in both blocks. Releasing 2.0.1 should not match 1.0.x
@@ -300,6 +264,7 @@ class TestUpdateVersionsModule:
         assert result["8.1"]["modules"]["valkey-search"]["version"] == "1.0.1"  # unchanged
 
     def test_module_major_release_only_updates_latest(self, versions_data, mocker):
+        mocker.patch.object(update_versions, "get_debian_version", return_value="bookworm")
         self._no_open_pr(mocker)
         # For major module release, valkey must be X.0.0
         versions_data["9.0"]["valkey-server"]["version"] = "9.0.0"
@@ -319,6 +284,7 @@ class TestUpdateVersionsModule:
             update_versions_fn(versions_data, "json", "1.1.0")
 
     def test_module_minor_release_allowed_when_valkey_minor_gt_zero(self, versions_data_three_blocks, mocker):
+        mocker.patch.object(update_versions, "get_debian_version", return_value="bookworm")
         self._no_open_pr(mocker)
         # 9.1 is latest, valkey-server is 9.1.0-rc1 (minor=1), so module minor release should be allowed
         result = update_versions_fn(versions_data_three_blocks, "json", "1.1.0")
@@ -328,12 +294,14 @@ class TestUpdateVersionsModule:
         assert result["9.0"]["modules"]["valkey-json"]["version"] == "1.0.1"
 
     def test_module_major_release_allowed_with_rc_valkey(self, versions_data, mocker):
+        mocker.patch.object(update_versions, "get_debian_version", return_value="bookworm")
         self._no_open_pr(mocker)
         versions_data["9.0"]["valkey-server"]["version"] = "9.0.0-rc1"
         result = update_versions_fn(versions_data, "json", "2.0.0")
         assert result["9.0"]["modules"]["valkey-json"]["version"] == "2.0.0"
 
     def test_module_bumps_bundle_patch_when_no_pr(self, versions_data, mocker):
+        mocker.patch.object(update_versions, "get_debian_version", return_value="bookworm")
         self._no_open_pr(mocker)
 
         original_bundle = versions_data["9.0"]["version"]  # "9.0.1"
@@ -341,6 +309,7 @@ class TestUpdateVersionsModule:
         assert result["9.0"]["version"] == "9.0.2"
 
     def test_module_bumps_rc_when_bundle_is_rc(self, versions_data_rc, mocker):
+        mocker.patch.object(update_versions, "get_debian_version", return_value="bookworm")
         self._no_open_pr(mocker)
 
         # Bundle is 9.0.1-rc2, valkey-server is 9.0.2-rc1
@@ -359,6 +328,7 @@ class TestUpdateVersionsModule:
             raise subprocess.CalledProcessError(1, "unknown")
 
         mocker.patch("subprocess.check_output", side_effect=mock_check_output)
+        mocker.patch.object(update_versions, "get_debian_version", return_value="bookworm")
         original_bundle = versions_data["9.0"]["version"]
         result = update_versions_fn(versions_data, "json", "1.0.2")
         assert result["9.0"]["version"] == original_bundle
@@ -379,9 +349,25 @@ class TestUpdateVersionsModule:
             raise subprocess.CalledProcessError(1, "unknown")
 
         mocker.patch("subprocess.check_output", side_effect=mock_check_output)
+        mocker.patch.object(update_versions, "get_debian_version", return_value="bookworm")
 
         result = update_versions_fn(versions_data_three_blocks, "json", "1.0.2")
         # 8.1 should bump (mainline matches current)
         assert result["8.1"]["version"] == "8.1.3"
         # 9.0 should NOT bump (mainline differs — already bumped)
         assert result["9.0"]["version"] == "9.0.1"
+
+    def test_module_update_syncs_unstable_debian(self, versions_data, mocker):
+        def mock_check_output(*args, **kwargs):
+            cmd = args[0] if args else kwargs.get('args', [])
+            if cmd[0] == 'git' and 'ls-remote' in cmd:
+                raise subprocess.CalledProcessError(1, "git")
+            if cmd[0] == 'git' and 'show' in cmd:
+                return json.dumps(versions_data)
+            raise subprocess.CalledProcessError(1, "unknown")
+
+        mocker.patch("subprocess.check_output", side_effect=mock_check_output)
+        mocker.patch.object(update_versions, "get_debian_version", return_value="trixie")
+
+        result = update_versions_fn(versions_data, "json", "1.0.2")
+        assert result["unstable"]["debian"]["version"] == "trixie"

--- a/unstable/alpine/Dockerfile
+++ b/unstable/alpine/Dockerfile
@@ -37,10 +37,10 @@ WORKDIR /opt
 
 # Clone repositories
 RUN set -eux; \
-    git clone --depth 1 --branch 1.0.2 https://github.com/valkey-io/valkey-json.git; \
-    git clone --depth 1 --branch 1.0.1 https://github.com/valkey-io/valkey-bloom.git; \
-    git clone --depth 1 --branch 1.2.0 https://github.com/valkey-io/valkey-search.git; \
-    git clone --depth 1 --branch 1.1.0 https://github.com/valkey-io/valkey-ldap.git;
+    git clone --depth 1 --branch unstable https://github.com/valkey-io/valkey-json.git; \
+    git clone --depth 1 --branch unstable https://github.com/valkey-io/valkey-bloom.git; \
+    git clone --depth 1 --branch main https://github.com/valkey-io/valkey-search.git; \
+    git clone --depth 1 --branch main https://github.com/valkey-io/valkey-ldap.git;
 
 # Build JSON module
 WORKDIR /opt/valkey-json

--- a/unstable/debian/Dockerfile
+++ b/unstable/debian/Dockerfile
@@ -38,10 +38,10 @@ WORKDIR /opt
 
 # Clone repositories
 RUN set -eux; \
-    git clone --depth 1 --branch 1.0.2 https://github.com/valkey-io/valkey-json.git; \
-    git clone --depth 1 --branch 1.0.1 https://github.com/valkey-io/valkey-bloom.git; \
-    git clone --depth 1 --branch 1.2.0 https://github.com/valkey-io/valkey-search.git; \
-    git clone --depth 1 --branch 1.1.0 https://github.com/valkey-io/valkey-ldap.git;
+    git clone --depth 1 --branch unstable https://github.com/valkey-io/valkey-json.git; \
+    git clone --depth 1 --branch unstable https://github.com/valkey-io/valkey-bloom.git; \
+    git clone --depth 1 --branch main https://github.com/valkey-io/valkey-search.git; \
+    git clone --depth 1 --branch main https://github.com/valkey-io/valkey-ldap.git;
 
 # Build JSON module
 WORKDIR /opt/valkey-json

--- a/versions.json
+++ b/versions.json
@@ -6,16 +6,16 @@
     },
     "modules": {
       "valkey-json": {
-        "version": "1.0.2"
+        "version": "unstable"
       },
       "valkey-bloom": {
-        "version": "1.0.1"
+        "version": "unstable"
       },
       "valkey-search": {
-        "version": "1.2.0"
+        "version": "main"
       },
       "valkey-ldap": {
-        "version": "1.1.0"
+        "version": "main"
       }
     },
     "debian": {


### PR DESCRIPTION
- Set module versions in unstable block to their dev branches (unstable for json/bloom, main for search/ldap)
- Remove update_unstable() function and CLI path (no longer needed)
- Sync unstable debian version during any valkey/module update
- Fix integration test to clone all modules from configured branch